### PR TITLE
Fix formatting in CLI tutorial and style bug.

### DIFF
--- a/Using-the-Kite-CLI-to-Create-a-Dataset.md
+++ b/Using-the-Kite-CLI-to-Create-a-Dataset.md
@@ -26,7 +26,6 @@ If you have a CSV file sitting around waiting to be used, you can substitute you
 If you don't have a CSV file handy, you can copy the next code snippet and save it as a plain text file named *sandwiches.csv*.
 
 ```
-
 name, description
 Reuben, Pastrami and sauerkraut on toasted rye with Russian dressing.
 PBJ, Peanut butter and grape jelly on white bread.
@@ -36,11 +35,13 @@ PBJ, Peanut butter and grape jelly on white bread.
 
 All right. Now we get to use the CLI. Start by inferring an Avro schema file from the *sandwiches.csv* file you just created. Enter the following command to create an Avro schema file named *sandwich.avsc* with the class name *Sandwich*. The schema details are based on the headings and data in *sandwiches.csv*.
 
-`dataset csv-schema sandwiches.csv --class Sandwich -o sandwich.avsc`
+```
+dataset csv-schema sandwiches.csv --class Sandwich -o sandwich.avsc
+```
 
 If you open *sandwich.avsc* in a text editor, it looks something like the code block below. `csv-schema` infers the names of the columns from the header, and the data type for each column from the first row of values.
 
-```
+```json
 {
   "type" : "record",
   "name" : "Sandwich",
@@ -48,11 +49,11 @@ If you open *sandwich.avsc* in a text editor, it looks something like the code b
   "fields" : [ {
     "name" : "name",
     "type" : [ "null", "string" ],
-    "doc" : "Type inferred from \"Reuben\""
+    "doc" : "Type inferred from 'Reuben'"
   }, {
     "name" : "description",
     "type" : [ "null", "string" ],
-    "doc" : "Type inferred from \" Pastrami and sauerkraut on toasted rye with Russian dressing.\""
+    "doc" : "Type inferred from ' Pastrami and sauerkraut on toasted rye with Russian dressing.'"
   } ]
 }
 ```
@@ -61,17 +62,21 @@ If you open *sandwich.avsc* in a text editor, it looks something like the code b
 
 With a schema, you can create a new dataset. Enter the following command.
 
-`dataset create sandwiches -s sandwich.avsc`
+```
+dataset create sandwiches -s sandwich.avsc
+```
 
 While it does not create actual sandwiches, it does create an empty dataset in which you can store sandwich descriptions, which is the next best thing. Probably.
 
 Just for giggles, you can reverse the process you just completed and look at the underlying schema of your dataset using the following command.
 
-`dataset schema sandwiches`
+```
+dataset schema sandwiches
+```
 
 You'll get the same schema back, but this time, trust me, it's coming from the Hive repository. Honest.
 
-```
+```json
 {
   "type" : "record",
   "name" : "Sandwich",
@@ -79,11 +84,11 @@ You'll get the same schema back, but this time, trust me, it's coming from the H
   "fields" : [ {
     "name" : "name",
     "type" : [ "null", "string" ],
-    "doc" : "Type inferred from \"Reuben\""
+    "doc" : "Type inferred from 'Reuben'"
   }, {
     "name" : "description",
     "type" : [ "null", "string" ],
-    "doc" : "Type inferred from \" Pastrami and sauerkraut on toasted rye with Russian dressing.\""
+    "doc" : "Type inferred from ' Pastrami and sauerkraut on toasted rye with Russian dressing.'"
   } ]
 }
 ```
@@ -91,10 +96,15 @@ You'll get the same schema back, but this time, trust me, it's coming from the H
 ### Import the CSV Data
 You've created a dataset in the Hive repository, which is the container, but not the information itself. Next, you might want to add some data so that you can run some queries. Use the following command to import the sandwiches in your CSV file.
 
-`dataset csv-import sandwiches.csv sandwiches`
+```
+dataset csv-import sandwiches.csv sandwiches
+```
 
-The method returns a record count. 
-`Added 2 records to dataset "sandwiches"`
+The method returns a record count.
+
+```
+Added 2 records to dataset "sandwiches"
+```
 
 But can you believe that? Inquiring minds want to verify that the information is actually in the dataset.
 
@@ -102,22 +112,28 @@ But can you believe that? Inquiring minds want to verify that the information is
 
 You can list records from your newly created dataset using the `show` command.
 
-`dataset show sandwiches`
+```
+dataset show sandwiches
+```
 
 By default, CLI retrieves up to the first 10 records from your dataset.
 
-```
+```json
 {"name": "Reuben", "description": " Pastrami and sauerkraut on toasted rye with Russian dressing."}
 {"name": "PBJ", "description": " Peanut butter and grape jelly on white bread."}
 ```
 
 If you find that number of sandwiches overwhelming, you can change the number of records the query returns.
 
-`dataset show sandwiches -n 1`
+```
+dataset show sandwiches -n 1
+```
 
 This time only the first record prints to screen.
 
-`{"name": "Reuben", "description": " Pastrami and sauerkraut on toasted rye with Russian dressing."}`
+```json
+{"name": "Reuben", "description": " Pastrami and sauerkraut on toasted rye with Russian dressing."}
+```
 
 You can import additional records to the database and use Hive or Impala to query the results.
 
@@ -125,7 +141,9 @@ You can import additional records to the database and use Hive or Impala to quer
 
 Given the ease with which you just created the sandwiches dataset, it seems a shame to destroy it out of hand. Keep in mind that this was only an example, and not something you were meant to treasure. I suppose you don't have to delete it, you might want to keep it around as a souvenir, like the first dollar earned or something like that. If so, create a dataset you hate, and prepare to annihilate it using this unassuming command.
 
-`dataset delete sandwiches`
+```
+dataset delete sandwiches
+```
 
 There they go. Reuben and PBJ are gone. But you can create them again, or any other dataset you choose, using the CLI.
 

--- a/css/main.css
+++ b/css/main.css
@@ -255,7 +255,7 @@ table td {
   font-size: 15px;
 }
 
-.post code { padding: 1px 5px; }
+.post code { padding: 1px 0px; }
 
 .post ul,
 .post ol { margin-left: 1.35em; }


### PR DESCRIPTION
The style bug causes the first line of a non-highlighted code block to
be indented 5px. I've removed the padding to fix the problem.
