### PR TITLE
Update Column-Mapping headings for jekyll style.

### DIFF
--- a/Column-Mapping.md
+++ b/Column-Mapping.md
@@ -34,12 +34,12 @@ Each source field should have a corresponding column definition in the complete 
 
 There are five mapping types: _column_, _counter_, _keyAsColumn_, _key_, and _version_.
 
-### `column`
+### Column mapping
 The `column` type maps a value to a single cell identified by the `family` and `qualifier` properties.
 
 The value in a cell is not necessarily a primitive type. It can be a more complex type, such as an entire Avro record or table.
 
-### `counter` 
+### Counter mapping
 The `counter` is similar to column, but can be incremented using HBase's atomic increment. The field data is stored in a cell identified by the required `family` and `qualifier` properties, and the source field for a counter must be an integer or a long. A good example is user visits to a website. Every time the user visits the site, the site increments the user's visit counter.
 
 ```json
@@ -54,11 +54,33 @@ HBase increments the counter atomically. If there are two visits at the same tim
 
 Even if another user reads the value and begins an edit in between, HBase guarantees that the information is stored correctly (that is, your change will not overwrite changes made concurrently).
 
-### `keyAsColumn`
+### Key mapping
 
-Use `keyAsColumn` to store a complex record or map in a particular column family. 
+HBase stores everything by a unique key for each record, made from the record's data. For example, users might be stored by their e-mail address. You could use `column` to store the e-mail in a cell, but it is already stored in key for the record. Kite can retrieve the email value from the key. It doesn't have to be stored a second time in the data.
 
-For example, if you store locations made of a latitude, longitude pair, you could map the location record in the `loc` family using the following mapping.
+```json
+{"source" : "email", "type" : "key"}
+```
+
+In Kite, we define the key using a partition strategy. For the above e-mail mapping, you would need to use a partition strategy that includes the e-mail like this.
+
+```json
+[
+  {"source" : "email", "type" : "identity"}
+]
+```
+
+On the file system side, the keys overlap. That’s how we group things together into common buckets that have properties such as Year, Month, and Day for all of the events in the same bucket.
+
+HBase does that partitioning for you: it groups items together based on unique keys. If it needs to, it will split the file when it gets to be of sufficient size. The keys don't point to a group. The keys point to an individual record, and then groups are made from those keys, dynamically.
+
+What you want to do is take your unique identifiers and store those as your keys.
+
+### Complex record mapping
+
+Use `keyAsColumn` to store a complex record or a hash map in a particular column family. 
+
+For example, if you store locations made of a latitude, longitude pair, you could store the location record in the `loc` family using the following mapping.
 
 ```json
 {"source" : "location", "type" : "keyAsColumn", "family" : "loc"}
@@ -85,29 +107,7 @@ A `keyAsColumn` source field must be a record or a map. The difference when usin
 
 The fields in the record or map can themselves be complex objects.
 
-### `key`
-
-HBase stores everything by a unique key for each record, made from the record's data. For example, users might be stored by their e-mail address. You could use `column` to store the e-mail in a cell, but it is already stored in key for the record. Kite can retrieve the email value from the key. It doesn't have to be stored a second time in the data.
-
-```json
-{"source" : "email", "type" : "key"}
-```
-
-In Kite, we define the key using a partition strategy. For the above e-mail mapping, you would need to use a partition strategy that includes the e-mail like this.
-
-```json
-[
-  {"source" : "email", "type" : "identity"}
-]
-```
-
-On the file system side, the keys overlap. That’s how we group things together into common buckets that have properties such as Year, Month, and Day for all of the events in the same bucket.
-
-HBase does that partitioning for you: it groups items together based on unique keys. If it needs to, it will split the file when it gets to be of sufficient size. The keys don't point to a group. The keys point to an individual record, and then groups are made from those keys, dynamically.
-
-What you want to do is take your unique identifiers and store those as your keys.
-
-### `occVersion`
+### Version mapping
 
 The `occVersion` mapping is a special type of counter. It's the only counter allowed on the record. Counters use atomic updating, where the increment is handled inside the database. Version, being the version of the record, is the only counter allowed. It has an automatic storage system that the user cannot control. You can access the version on the record itself, but you have no opportunity to change the value. 
 


### PR DESCRIPTION
Moving to Jekyll changed the way headings with fixed-width text appear.
They no longer appeared as headings, so I've replaced them with proper
heading text.

I also moved the key mapping up so the mappings appear in order of
usefulness and complexity.
