### PR TITLE
Changed update-dataset to update in the syntax for update command

### DIFF
--- a/Kite-Dataset-Command-Line-Interface.md
+++ b/Kite-Dataset-Command-Line-Interface.md
@@ -214,7 +214,7 @@ Update the metadata descriptor for a dataset.
 ### Syntax
 
 ```
-{{site.dataset-command}} [-v] update-dataset <dataset> [command options]
+{{site.dataset-command}} [-v] update <dataset> [command options]
 ```
 
 ### Options


### PR DESCRIPTION
One-line change in docs. I'm guessing "update-dataset" changed to "update" at some point.
