### PR TITLE
CDK-751: Add Kite start page as index.html.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,13 +1,20 @@
 # Site settings
-title: Kite SDK Development Guide
+title: Kite Development Guide
 email: cdk-dev@cloudera.org
-description: "Documentation for the Kite open source project on GitHub."
+description: "An open source data API for Hadoop."
 baseurl: "/docs/current/guide"
 url: "http://kitesdk.org"
-include: ["./samples/"]
+
+license_url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+github_url: "https://github.com/kite-sdk/kite"
+issue_tracker_url: "https://issues.cloudera.org/browse/CDK"
+mailing_list_url: "https://groups.google.com/a/cloudera.org/forum/#!forum/cdk-dev"
+contributing_url: "https://github.com/kite-sdk/kite/wiki/How-to-contribute"
+
 dataset-command: "kite-dataset"
 
 # Build settings
+include: ["./samples/"]
 markdown: kramdown
 permalink: pretty
 kramdown:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,59 +1,39 @@
 <footer class="site-footer">
 
-  <div class="wrap">
+  <div class="wrap columns">
 
-    <h2 class="footer-heading">{{ site.title }}</h2>
+    <div class="left">
+      <h2 class="footer-heading">{{ site.title }}</h2>
 
-    <div class="footer-col-1 column">
       <ul>
-        <li>{{ site.title }}</li>
-        <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
+        <li>Kite is licensed under</li>
+        <li><a href="{{ site.license_url }}">The Apache License, Version 2.0</a></li>
       </ul>
     </div>
 
-    <div class="footer-col-2 column">
-      <ul>
-        <li>
-          <a href="https://github.com/{{ site.username }}">
-            <span class="icon github">
-              <svg version="1.1" class="github-icon-svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-                 viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
-                <path fill-rule="evenodd" clip-rule="evenodd" fill="#C2C2C2" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761
-                c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32
-                c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472
-                c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037
-                C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65
-                c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261
-                c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082
-                c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129
-                c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/>
-              </svg>
-            </span>
-            <span class="username">{{ site.username }}</span>
-          </a>
-        </li>
-        <li>
-          <a href="https://twitter.com/{{ site.username }}">
-            <span class="icon twitter">
-              <svg version="1.1" class="twitter-icon-svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-                 viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
-                <path fill="#C2C2C2" d="M15.969,3.058c-0.586,0.26-1.217,0.436-1.878,0.515c0.675-0.405,1.194-1.045,1.438-1.809
-                c-0.632,0.375-1.332,0.647-2.076,0.793c-0.596-0.636-1.446-1.033-2.387-1.033c-1.806,0-3.27,1.464-3.27,3.27
-                c0,0.256,0.029,0.506,0.085,0.745C5.163,5.404,2.753,4.102,1.14,2.124C0.859,2.607,0.698,3.168,0.698,3.767
-                c0,1.134,0.577,2.135,1.455,2.722C1.616,6.472,1.112,6.325,0.671,6.08c0,0.014,0,0.027,0,0.041c0,1.584,1.127,2.906,2.623,3.206
-                C3.02,9.402,2.731,9.442,2.433,9.442c-0.211,0-0.416-0.021-0.615-0.059c0.416,1.299,1.624,2.245,3.055,2.271
-                c-1.119,0.877-2.529,1.4-4.061,1.4c-0.264,0-0.524-0.015-0.78-0.046c1.447,0.928,3.166,1.469,5.013,1.469
-                c6.015,0,9.304-4.983,9.304-9.304c0-0.142-0.003-0.283-0.009-0.423C14.976,4.29,15.531,3.714,15.969,3.058z"/>
-              </svg>
-            </span>
-            <span class="username">{{ site.username }}</span>
-          </a>
-        </li>
-      </ul>
+    <div class="middle">
     </div>
 
-    <div class="footer-col-3 column">
-      <p class="text">{{ site.description }}</p>
+    <div class="right">
+      <p class="text">{{ site.description }}
+        <div class="columns">
+          <div class="left">
+            <ul>
+              <li><a href="{{ site.github_url }}"><i class="fa fa-github fa-lg"></i>&nbsp; Source</a></li>
+              <li><a href="{{ site.issue_tracker_url }}"><i class="fa fa-bug fa-lg"></i>&nbsp; Issue tracking</a></li>
+              <li><a href="{{ site.mailing_list_url }}"><i class="fa fa-comments-o fa-lg"></i>&nbsp; Mailing list</a></li>
+              <li><a href="{{ site.contributing_url }}"><i class="fa fa-cogs fa-lg"></i>&nbsp; How to contribute</a></li>
+            </ul>
+          </div>
+          <div class="right">
+            <ul>
+              <li><a href="{{ site.javadoc_url }}"><i class="fa fa-file-text-o"></i>&nbsp; API Javadoc</a></li>
+              <li><a href="{{ site.jdiff_url }}"><i class="fa fa-bolt fs-lg"></i>&nbsp; API Changes</a></li>
+              <li><a href="{{ site.baseurl }}/release-notes"><i class="fa fa-info fa-lg"></i>&nbsp; Release Notes</a></li>
+            </ul>
+          </div>
+        </div>
+      </p>
     </div>
 
   </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,5 +8,7 @@
 
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css">
+    <link href='http://fonts.googleapis.com/css?family=Raleway:200,400,500,600,700' rel='stylesheet' type='text/css'>
+    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 
 </head>

--- a/all-pages.md
+++ b/all-pages.md
@@ -1,0 +1,34 @@
+---
+layout: page
+title: Kite SDK Documentation
+---
+
+This is the default landing page for Kite SDK documentation.
+
+## Kite SDK Overview
+
+
+* [What is Kite? (and What Makes It So Awesome?)](Kite-SDK-Guide/)
+* [Kite Data Module Overview](Kite-Data-Module-Overview/)
+* [Kite Dataset Lifecycle](lifecycle/)
+
+
+
+## Kite Dataset Command Line Interface
+
+* [Install the Kite CLI](Install-Kite/)
+* [Kite SDK Dataset CLI](Kite-Dataset-Command-Line-Interface/)
+* [Using the Kite Dataset CLI to Create a Dataset](Using-the-Kite-CLI-to-Create-a-Dataset/)
+* [Viewing the Kite Dataset Using Impala](Viewing-with-Impala/)
+
+
+## Conceptual Topics
+
+* [Parquet vs Avro Format](Parquet-vs-Avro-Format/)
+* [Partitioned Datasets](Partitioned-Datasets/)
+* [Column Mapping](Column-Mapping/)
+* [HBase Storage Cells](HBase-Storage-Cells/)
+* [Schema Evolution](Schema-Evolution/)
+* [Restricted Views](Restricted-Views/)
+* [Dataset URIs](URIs/)
+* [Using Kite with Apache Maven](Using-Kite-with-Apache-Maven/)

--- a/css/main.css
+++ b/css/main.css
@@ -14,10 +14,10 @@ td.code {
 html, body { height: 100%; }
 
 body {
-  font-family: Palatino, TimesRoman, Serif;
+  font-family: 'Raleway', sans-serif;
   font-size: 16px;
   line-height: 1.5;
-  font-weight: 300;
+  font-weight: 400;
   background-color: #fdfdfd;
 }
 
@@ -41,6 +41,58 @@ table td {
   padding: 0.2em;
 }
 
+.left {
+  float: left;
+  clear: left;
+  overflow: auto;
+}
+
+.center {
+  text-align: center;
+}
+
+.right {
+  float: right;
+  clear: right;
+  overflow: auto;
+}
+
+.post-content .left {
+  min-width: 40%;
+  margin-right: 2em;
+}
+
+.post-content .right {
+  min-width: 40%;
+  margin-left: 2em;
+}
+
+.columns {
+  display: table;
+  width: 100%;
+}
+
+.columns .left {
+  float: none;
+  display: table-cell;
+  vertical-align: middle;
+  width: 47.5%;
+}
+
+.columns .middle {
+  display: table-cell;
+  vertical-align: middle;
+  text-align: center;
+  width: 5%;
+}
+
+.columns .right {
+  float: none;
+  display: table-cell;
+  vertical-align: middle;
+  width: 47.5%;
+}
+
 /* Utility */
 
 .wrap:before,
@@ -61,9 +113,9 @@ table td {
 
 .site-header {
   border-top: 5px solid #333;
-  border-bottom: 1px solid #e8e8e8;
+  border-bottom: 1px solid #d5d5e9;
   min-height: 56px;
-  background-color: white;
+  background-color: #fafafe;
 }
 
 .site-title,
@@ -95,13 +147,14 @@ table td {
 /* Site footer */
 
 .site-footer {
-  border-top: 1px solid #e8e8e8;
+  border-top: 1px solid #d5d5e9;
+  background-color: #fafafe;
   padding: 30px 0;
 }
 
 .footer-heading {
   font-size: 18px;
-  font-weight: 300;
+  font-weight: 400;
   letter-spacing: -.5px;
   margin-bottom: 15px;
 }
@@ -139,15 +192,6 @@ table td {
   font-size: 15px;
   letter-spacing: -.3px;
   color: #828282;
-}
-
-.github-icon-svg,
-.twitter-icon-svg {
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  position: relative;
-  top: 3px;
 }
 
 
@@ -191,7 +235,8 @@ table td {
   font-size: 42px;
   letter-spacing: -1.75px;
   line-height: 1;
-  font-weight: 300;
+  font-weight: 500;
+
 }
 
 .post-header .meta {
@@ -212,7 +257,7 @@ table td {
 .post-content h5,
 .post-content h6 {
   line-height: 1;
-  font-weight: 300;
+  font-weight: 400;
   margin: 40px 0 20px;
 }
 
@@ -246,6 +291,7 @@ table td {
 
 .post pre,
 .post code {
+  font-family: monospace;
   border: 1px solid #d5d5e9;
   background-color: #eef;
   padding: 8px 12px;
@@ -274,6 +320,10 @@ table td {
 }
 
 .post pre.terminal code { background-color: #333; }
+
+.post .no-line-numbers .line-numbers {
+  visibility: hidden;
+}
 
 /* Syntax highlighting styles */
 /* ----------------------------------------------------------*/

--- a/index.md
+++ b/index.md
@@ -1,34 +1,86 @@
 ---
 layout: page
-title: Kite SDK Documentation
+title: 'A Data API for Hadoop'
 ---
 
-This is the default landing page for Kite SDK documentation.
+Kite is a high-level data layer for Hadoop. It is an API and a set of tools that speed up development. You configure how Kite stores your data in Hadoop, instead of building and maintaining that infrastructure yourself.
 
-## Kite SDK Overview
+## High-level tools
 
+Kite's API and tools are built around datasets. Datasets are uniquely identified URIs, like `dataset:hive:ratings`.
 
-* [What is Kite? (and What Makes It So Awesome?)](Kite-SDK-Guide/)
-* [Kite Data Module Overview](Kite-Data-Module-Overview/)
-* [Kite Dataset Lifecycle](lifecycle/)
+Dataset is a consistent interface for working with your data. You have control of implementation details, such as whether to use Avro or Parquet format, HDFS or HBase storage, and snappy compression or another. You only have to tell Kite what to do; Kite handles the implementation for you.
 
+<div class="right">
+{% highlight text %}
+$> kite-dataset csv-import ratings.csv \
+              dataset:hbase:zk/ratings
+Added 1000000 records to dataset "ratings"
+{% endhighlight %}
+</div>
 
+Kite's command-line interface helps you manage datasets with pre-built tasks like creating datasets, migrating schemas, and loading data. It also helps you configure Kite and other Hadoop projects.
 
-## Kite Dataset Command Line Interface
+[<i class="fa fa-chevron-right"></i>&nbsp; Get started with Kite's CSV tutorial][kite-cli]
 
-* [Install the Kite CLI](Install-Kite/)
-* [Kite SDK Dataset CLI](Kite-Dataset-Command-Line-Interface/)
-* [Using the Kite Dataset CLI to Create a Dataset](Using-the-Kite-CLI-to-Create-a-Dataset/)
-* [Viewing the Kite Dataset Using Impala](Viewing-with-Impala/)
+<div class="left">
+{% highlight java %}
+View latest = Datasets.load(uri)
+    .from("time", startOfToday)
+    .to("time", now);
+{% endhighlight %}
+</div>
 
+Kite's data API provides programmatic access to datasets. Using the API, you can build applications that directly interact with your datasets. For example, you can load a dataset and select a subset of it for a MapReduce pipeline.
 
-## Conceptual Topics
+[<i class="fa fa-chevron-right"></i>&nbsp; Learn more about Kite datasets][kite-data-overview]
 
-* [Parquet vs Avro Format](Parquet-vs-Avro-Format/)
-* [Partitioned Datasets](Partitioned-Datasets/)
-* [Column Mapping](Column-Mapping/)
-* [HBase Storage Cells](HBase-Storage-Cells/)
-* [Schema Evolution](Schema-Evolution/)
-* [Restricted Views](Restricted-Views/)
-* [Dataset URIs](URIs/)
-* [Using Kite with Apache Maven](Using-Kite-with-Apache-Maven/)
+## Low-level control
+
+When you create a dataset, uou control your data layout, record schema, and other options with straight-forward configuration. Then you can focus on building your application, while Kite handles data storage for you. Kite automatically partitions records when writing and prunes partitions when reading. It will even keep Hive up-to-date with a dataset's newest partitions.
+
+<div class="columns">
+  <div class="left">
+{% highlight text %}
+time,rating,user_id,item_id
+1412361369702,4,34,18865
+...
+{% endhighlight %}
+    <div class="center"><i class="fa fa-plus"></i></div>
+{% highlight json %}
+[
+  {"type": "year", "source": "time"},
+  {"type": "month", "source": "time"},
+  {"type": "day", "source": "time"},
+]
+{% endhighlight %}
+  </div>
+  <div class="middle"><i class="fa fa-arrow-right"></i></div>
+  <div class="right">
+{% highlight text %}
+datasets/
+└── ratings/
+    └── year=2014/
+        ├── month=09/
+        │   ├── day=01/
+        │   ├── ...
+        │   └── day=30/
+        ├── month=10/
+        │   ├── day=01/
+        │   ├── ...
+{% endhighlight %}
+  </div>
+</div>
+
+[<i class="fa fa-chevron-right"></i>&nbsp; Learn more about configuring Kite][kite-config]
+
+## Configuration-based transformation
+
+Kite morphlines is a flexible way to express data transformations as configuration.
+
+[<i class="fa fa-chevron-right"></i>&nbsp; Go to the Morphlines reference guide][morphlines-intro]
+
+[kite-cli]: {{ site.baseurl }}/Using-the-Kite-CLI-to-Create-a-Dataset
+[kite-data-overview]: {{ site.baseurl }}/Kite-Data-Module-Overview
+[kite-config]: {{ site.baseurl }}/configuraton-formats
+[morphlines-intro]: /docs/latest/kite-morphlines/index.html


### PR DESCRIPTION
This includes Dennis's edits from CDK-751.

The existing index has been moved to all-pages.md. This needs to be
improved before committing, possibly by organizing all pages and adding
a sidebar rather than using all-pages directly.

This is a subset of the changes from the original proposed branch, which I'm breaking up into multiple pull requests. this one just includes the front page changes and updates to the style to replace the old side, like adding footer links to the issue tracker and github.
