### PR TITLE
CDK-767: Update CLI docs for 0.17.1 changes.

### DIFF
--- a/Kite-Data-Module-Overview.md
+++ b/Kite-Data-Module-Overview.md
@@ -56,8 +56,8 @@ The goal is to get the schema into `.avsc` format and store it in the Hadoop fil
 
 | Java API | Command Line Interface |
 | --------- | ----------------------- |
-| [Inferring a schema from a Java Class](../Inferring-a-Schema-from-a-Java-Class/) | [Inferring a schema from a Java class](../Kite-Dataset-Command-Line-Interface#objSchema) |
-| [Inferring a schema from an Avro data file](../Inferring-a-Schema-from-an-Avro-Data-File) | [Inferring a schema from a CSV file](../Kite-Dataset-Command-Line-Interface#csvSchema) |
+| [Inferring a schema from a Java Class](../Inferring-a-Schema-from-a-Java-Class/) | [Inferring a schema from a Java class](../Kite-Dataset-Command-Line-Interface#obj-schema) |
+| [Inferring a schema from an Avro data file](../Inferring-a-Schema-from-an-Avro-Data-File) | [Inferring a schema from a CSV file](../Kite-Dataset-Command-Line-Interface#csv-schema) |
 
 
 
@@ -88,7 +88,7 @@ Each dataset belongs to exactly one dataset repository. Kite doesn&apos;t provid
 
 ## Loading Data from CSV
 
-You can load comma separated value data into a dataset repository using the command line interface function [csv-import](../Kite-Dataset-Command-Line-Interface/index.html#csvImport). 
+You can load comma separated value data into a dataset repository using the command line interface function [csv-import](../Kite-Dataset-Command-Line-Interface/index.html#csv-import). 
 
 <a name="writers" />
 

--- a/Kite-Dataset-Command-Line-Interface.md
+++ b/Kite-Dataset-Command-Line-Interface.md
@@ -24,9 +24,9 @@ Each command is described below. See [Using the Kite CLI to Create a Dataset](..
 * [schema](#schema) : view the schema for an existing dataset.
 * [info](#info): show metadata for a dataset.
 * [show](#show): show the first _n_ records of a dataset.
-* [csv-schema](#csvSchema): create a schema from a CSV data file.
-* [csv-import](#csvImport): import a CSV data file.
-* [obj-schema](#objSchema): create a schema from a Java object.
+* [csv-schema](#csv-schema): create a schema from a CSV data file.
+* [csv-import](#csv-import): import a CSV data file.
+* [obj-schema](#obj-schema): create a schema from a Java object.
 * [partition-config](#partition-config): create a partition strategy for a schema.
 * [mapping-config](#mapping-config): create a mapping strategy for a schema.
 * [log4j-config](#log4j-config): Configure Log4j.
@@ -66,11 +66,14 @@ flags="-Xmx512m" {{site.dataset-command}} info users`
 [Back to the Top](#top)
 
 ----
-<a name="csvSchema" />
 
 ## csv-schema
 
 Use `csv-schema` to generate an Avro schema from a comma separated value (CSV) file.
+
+The schema produced by this command is a record based on the first few lines of the file. If the first line is a header, it is used to name the fields.
+
+Field schemas are set by inspecting the first non-empty value in each field. Fields are nullable unless the field's name is passed using `--require`. Nullable fields default to `null`.
 
 ### Syntax
 
@@ -80,13 +83,14 @@ Use `csv-schema` to generate an Avro schema from a comma separated value (CSV) f
 
 ### Options
 
-| `--skip-lines`           | The number of lines to skip before the start of the CSV data. Default is 0. |
-| `--quote`                | Quote character in the CSV data file. Default is the double-quote ("). |
-| `--delimiter`            | Delimiter character in the CSV data file. Default is the comma (,). |
-| `--escape`               | Escape character in the CSV data file. Default is the backslash (\\). |
 | `--class,`<br />`--record-name` | A class name or record name for the schema result. This value is **required**. |
 | `-o, --output`           | Save schema avsc to path. |
+| `--require`              | Mark a field required; the schema for this field will not allow null values.<br />Use more than once to require multiple fields. |
 | `--no-header`            | Use this option when the CSV data file does not have header information in the first line.<br />Fields are given the default names *field_0*, *field_1,...field_n*. |
+| `--skip-lines`           | The number of lines to skip before the start of the CSV data. Default is 0. |
+| `--delimiter`            | Delimiter character in the CSV data file. Default is the comma (,). |
+| `--escape`               | Escape character in the CSV data file. Default is the backslash (\\). |
+| `--quote`                | Quote character in the CSV data file. Default is the double-quote ("). |
 | `--minimize`             | Minimize schema file size by eliminating white space. |
 
 ### Examples
@@ -109,10 +113,11 @@ Write the schema to sample.avsc:
 
 ----
 
-<a name="objSchema" />
-
 ## obj-schema
-Build a schema from a Java class. Fields are assumed to be nullable by default. You can edit the generated schema directly to remove the "null" option for specific fields.
+
+Build a schema from a Java class.
+
+Fields are assumed to be nullable if they are Objects, or required if they are primitives. You can edit the generated schema directly to remove the `null` option for specific fields.
 
 ### Syntax
 
@@ -280,11 +285,13 @@ dataset schema users -o user.avsc
 
 ----
 
-<a name="csvImport" />
-
 ## csv-import
 
 Copy CSV records into a dataset.
+
+Kite matches the CSV header to the target record schema's fields by name. If a header is not present (that is, you use the `--no-header` option), then CSV columns are matched with the target fields based on their position.
+
+As Kite constructs each record, it validates values using the target field's schema. Invalid values (in numeric fields) and null values (in required fields) cause exceptions. Kite handles empty strings as null values for numeric fields.
 
 ### Syntax
 
@@ -294,11 +301,11 @@ Copy CSV records into a dataset.
 
 ### Options
 
-| `--escape` | Escape character. Default is backslash (\\). |
-| `--delimiter` | Delimiter character. Default is comma (,). |
-| `--quote` | Quote character. Default is double quote ("). |
-| `--skip-lines` | Lines to skip before CSV start (default: 0) |
 | `--no-header` | Use this option when the CSV data file does not have header information in the first line.<br />Fields are given the default names *field_0*, *field_1,...field_n*. |
+| `--skip-lines` | Lines to skip before CSV start (default: 0) |
+| `--delimiter` | Delimiter character. Default is comma (,). |
+| `--escape` | Escape character. Default is backslash (\\). |
+| `--quote` | Quote character. Default is double quote ("). |
 
 ### Examples
 

--- a/Using-the-Kite-CLI-to-Create-a-Dataset.md
+++ b/Using-the-Kite-CLI-to-Create-a-Dataset.md
@@ -21,9 +21,9 @@ If you have a CSV file sitting around waiting to be used, you can substitute you
 If you don't have a CSV file handy, you can copy the next code snippet and save it as a plain text file named *sandwiches.csv*.
 
 ```
-name, description
-Reuben, Pastrami and sauerkraut on toasted rye with Russian dressing.
-PBJ, Peanut butter and grape jelly on white bread.
+name,description
+Reuben,Pastrami and sauerkraut on toasted rye with Russian dressing.
+PBJ,Peanut butter and grape jelly on white bread.
 ```
 
 ## Infer the Schema
@@ -44,11 +44,13 @@ If you open *sandwich.avsc* in a text editor, it looks something like the code b
   "fields" : [ {
     "name" : "name",
     "type" : [ "null", "string" ],
-    "doc" : "Type inferred from \"Reuben\""
+    "doc" : "Type inferred from 'Reuben'",
+    "default" : null
   }, {
     "name" : "description",
     "type" : [ "null", "string" ],
-    "doc" : "Type inferred from \" Pastrami and sauerkraut on toasted rye with Russian dressing.\""
+    "doc" : "Type inferred from 'Pastrami and sauerkraut on toasted rye with Russia'",
+    "default" : null
   } ]
 }
 ```
@@ -77,11 +79,13 @@ You'll get the same schema back, but this time, trust me, it's coming from the H
   "fields" : [ {
     "name" : "name",
     "type" : [ "null", "string" ],
-    "doc" : "Type inferred from \"Reuben\""
+    "doc" : "Type inferred from 'Reuben'",
+    "default" : null
   }, {
     "name" : "description",
     "type" : [ "null", "string" ],
-    "doc" : "Type inferred from \" Pastrami and sauerkraut on toasted rye with Russian dressing.\""
+    "doc" : "Type inferred from 'Pastrami and sauerkraut on toasted rye with Russia'",
+    "default" : null
   } ]
 }
 ```
@@ -112,8 +116,8 @@ You can list records from your newly created dataset using the `show` command.
 By default, CLI retrieves up to the first 10 records from your dataset.
 
 ```
-{"name": "Reuben", "description": " Pastrami and sauerkraut on toasted rye with Russian dressing."}
-{"name": "PBJ", "description": " Peanut butter and grape jelly on white bread."}
+{"name": "Reuben", "description": "Pastrami and sauerkraut on toasted rye with Russian dressing."}
+{"name": "PBJ", "description": "Peanut butter and grape jelly on white bread."}
 ```
 
 If you find that number of sandwiches overwhelming, you can change the number of records the query returns.
@@ -125,7 +129,7 @@ If you find that number of sandwiches overwhelming, you can change the number of
 This time only the first record prints to screen.
 
 ```
-{"name": "Reuben", "description": " Pastrami and sauerkraut on toasted rye with Russian dressing."}
+{"name": "Reuben", "description": "Pastrami and sauerkraut on toasted rye with Russian dressing."}
 ```
 
 You can import additional records to the database and use Hive or Impala to query the results.

--- a/lifecycle.md
+++ b/lifecycle.md
@@ -206,7 +206,7 @@ You can use the CLI command `csv-import` to insert records from a CSV file to yo
 {{site.dataset-command}} csv-import /kite/example/movie.csv movie
 ```
 
-See [`csv-import`](../Kite-Dataset-Command-Line-Interface/#csvImport) for additional options.
+See [`csv-import`](../Kite-Dataset-Command-Line-Interface/#csv-import) for additional options.
 
 ### Copy Dataset
 


### PR DESCRIPTION
This covers changes to document recent CSV issues, not just CDK-767.

This adds a description of how csv-schema infers types, handles
nullability, and sets default values. This also adds the --require
option.

Adds a warning about how records are validated to csv-import.
