### PR TITLE
Slight cleanup of `awk` (avoiding UUOC)

### DIFF
--- a/labs/5-create-a-partitioned-dataset-solution.md
+++ b/labs/5-create-a-partitioned-dataset-solution.md
@@ -10,7 +10,7 @@ This is the solution page for [Lab 5: Create a partitioned dataset][lab-5].
 
 ```
 echo "timestamp,user_id,movie_id,rating" > ratings.csv
-cat u.data | awk '{ print $4 "000," $1 "," $2 "," $3 }' | sort >> ratings.csv
+awk '{ print $4 "000," $1 "," $2 "," $3 }' u.data | sort -n >> ratings.csv
 ```
 
 Your `ratings.csv` file should now look like this:


### PR DESCRIPTION
Kill a UUOC, and `sort -n` in case we ever have any post-September 8, 2001 dates in the file (when Unix timestamp started to have an additional digit).